### PR TITLE
feat: add moon aspect tokens for sextile and opposition

### DIFF
--- a/backend/horary_engine/polarity_weights.py
+++ b/backend/horary_engine/polarity_weights.py
@@ -16,6 +16,12 @@ class TestimonyKey(Enum):
 
     MOON_APPLYING_TRINE_EXAMINER_SUN = "moon_applying_trine_examiner_sun"
     MOON_APPLYING_SQUARE_EXAMINER_SUN = "moon_applying_square_examiner_sun"
+    MOON_APPLYING_SEXTILE_EXAMINER_SUN = "moon_applying_sextile_examiner_sun"
+    MOON_APPLYING_SEXTILE_L1 = "moon_applying_sextile_l1"
+    MOON_APPLYING_SEXTILE_L7 = "moon_applying_sextile_l7"
+    MOON_APPLYING_OPPOSITION_EXAMINER_SUN = "moon_applying_opposition_examiner_sun"
+    MOON_APPLYING_OPPOSITION_L1 = "moon_applying_opposition_l1"
+    MOON_APPLYING_OPPOSITION_L7 = "moon_applying_opposition_l7"
     L10_FORTUNATE = "l10_fortunate"
     PERFECTION_DIRECT = "perfection_direct"
     PERFECTION_TRANSLATION_OF_LIGHT = "perfection_translation_of_light"
@@ -33,6 +39,14 @@ POLARITY_TABLE: dict[TestimonyKey, Polarity] = {
     TestimonyKey.MOON_APPLYING_TRINE_EXAMINER_SUN: Polarity.POSITIVE,
     # Example negative testimony
     TestimonyKey.MOON_APPLYING_SQUARE_EXAMINER_SUN: Polarity.NEGATIVE,
+    # Moon applying sextile aspects (positive)
+    TestimonyKey.MOON_APPLYING_SEXTILE_EXAMINER_SUN: Polarity.POSITIVE,
+    TestimonyKey.MOON_APPLYING_SEXTILE_L1: Polarity.POSITIVE,
+    TestimonyKey.MOON_APPLYING_SEXTILE_L7: Polarity.POSITIVE,
+    # Moon applying opposition aspects (negative)
+    TestimonyKey.MOON_APPLYING_OPPOSITION_EXAMINER_SUN: Polarity.NEGATIVE,
+    TestimonyKey.MOON_APPLYING_OPPOSITION_L1: Polarity.NEGATIVE,
+    TestimonyKey.MOON_APPLYING_OPPOSITION_L7: Polarity.NEGATIVE,
     # Fortunate outcome promised by L10
     TestimonyKey.L10_FORTUNATE: Polarity.POSITIVE,
     # Perfection testimonies are positive by default
@@ -47,6 +61,12 @@ POLARITY_TABLE: dict[TestimonyKey, Polarity] = {
 WEIGHT_TABLE: dict[TestimonyKey, float] = {
     TestimonyKey.MOON_APPLYING_TRINE_EXAMINER_SUN: 1.0,
     TestimonyKey.MOON_APPLYING_SQUARE_EXAMINER_SUN: 1.0,
+    TestimonyKey.MOON_APPLYING_SEXTILE_EXAMINER_SUN: 1.0,
+    TestimonyKey.MOON_APPLYING_SEXTILE_L1: 1.0,
+    TestimonyKey.MOON_APPLYING_SEXTILE_L7: 1.0,
+    TestimonyKey.MOON_APPLYING_OPPOSITION_EXAMINER_SUN: 1.0,
+    TestimonyKey.MOON_APPLYING_OPPOSITION_L1: 1.0,
+    TestimonyKey.MOON_APPLYING_OPPOSITION_L7: 1.0,
     TestimonyKey.L10_FORTUNATE: 1.0,
     TestimonyKey.PERFECTION_DIRECT: 1.0,
     TestimonyKey.PERFECTION_TRANSLATION_OF_LIGHT: 1.0,

--- a/backend/tests/test_moon_aspects_tokens.py
+++ b/backend/tests/test_moon_aspects_tokens.py
@@ -1,0 +1,79 @@
+import datetime
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+sys.path.append(str(ROOT))
+sys.path.append(str(ROOT / "backend"))
+
+from horary_engine.polarity_weights import TestimonyKey
+from horary_engine.aggregator import aggregate
+from horary_engine.rationale import build_rationale
+from horary_engine.polarity import Polarity
+from horary_engine.engine import extract_testimonies
+from models import Planet, Aspect, PlanetPosition, HoraryChart, Sign, AspectInfo
+
+
+def _make_pos(planet: Planet) -> PlanetPosition:
+    return PlanetPosition(
+        planet=planet,
+        longitude=0.0,
+        latitude=0.0,
+        house=1,
+        sign=Sign.ARIES,
+        dignity_score=0,
+        retrograde=False,
+        speed=1.0,
+    )
+
+
+def _make_chart() -> HoraryChart:
+    planets = {
+        Planet.MOON: _make_pos(Planet.MOON),
+        Planet.SUN: _make_pos(Planet.SUN),
+        Planet.MERCURY: _make_pos(Planet.MERCURY),
+    }
+    aspects = [
+        AspectInfo(Planet.MOON, Planet.SUN, Aspect.SEXTILE, 0.0, True),
+        AspectInfo(Planet.MOON, Planet.MERCURY, Aspect.OPPOSITION, 0.0, True),
+    ]
+    dt = datetime.datetime(2024, 1, 1)
+    return HoraryChart(
+        date_time=dt,
+        date_time_utc=dt,
+        timezone_info="UTC",
+        location=(0.0, 0.0),
+        location_name="Test",
+        planets=planets,
+        aspects=aspects,
+        houses=[0.0] * 12,
+        house_rulers={},
+        ascendant=0.0,
+        midheaven=0.0,
+    )
+
+
+def test_new_tokens_scoring_and_rationale():
+    tokens = [
+        TestimonyKey.MOON_APPLYING_SEXTILE_EXAMINER_SUN,
+        TestimonyKey.MOON_APPLYING_OPPOSITION_L1,
+    ]
+    score, ledger = aggregate(tokens)
+    assert score == 0.0
+    sextile_entry = next(e for e in ledger if e["key"] == TestimonyKey.MOON_APPLYING_SEXTILE_EXAMINER_SUN)
+    assert sextile_entry["polarity"] is Polarity.POSITIVE
+    assert sextile_entry["delta_yes"] == 1.0
+    opposition_entry = next(e for e in ledger if e["key"] == TestimonyKey.MOON_APPLYING_OPPOSITION_L1)
+    assert opposition_entry["polarity"] is Polarity.NEGATIVE
+    assert opposition_entry["delta_no"] == 1.0
+    rationale = build_rationale(ledger)
+    assert f"{TestimonyKey.MOON_APPLYING_SEXTILE_EXAMINER_SUN.value} (+1.0)" in rationale
+    assert f"{TestimonyKey.MOON_APPLYING_OPPOSITION_L1.value} (-1.0)" in rationale
+
+
+def test_extract_testimonies_emits_tokens():
+    chart = _make_chart()
+    contract = {"examiner": Planet.SUN, "querent": Planet.MERCURY}
+    primitives = extract_testimonies(chart, contract)
+    assert TestimonyKey.MOON_APPLYING_SEXTILE_EXAMINER_SUN in primitives
+    assert TestimonyKey.MOON_APPLYING_OPPOSITION_L1 in primitives


### PR DESCRIPTION
## Summary
- add sextile/opposition Moon testimony tokens with polarity and weights
- emit new Moon aspect tokens during extraction
- test scoring, rationale, and extraction for new tokens

## Testing
- `pytest tests/test_moon_aspects_tokens.py -q`
- `pytest -q` *(fails: FileNotFoundError: 'will I win the lottery.json')*

------
https://chatgpt.com/codex/tasks/task_e_68a6cd12f4c88324b148ec7426f620c4