### PR TITLE
Add category fortune/debility tokens and house lord extraction

### DIFF
--- a/backend/horary_engine/engine.py
+++ b/backend/horary_engine/engine.py
@@ -302,6 +302,29 @@ def extract_testimonies(chart: HoraryChart, contract: Dict[str, Planet]) -> List
         for dignity in reception_result.get("planet2_receives_planet1", []):
             primitives.append(dsl_reception(sig2, sig1, dignity))
 
+    # ------------------------------------------------------------------
+    # House lord conditions for key topics
+    # ------------------------------------------------------------------
+    house_map = {
+        7: (TestimonyKey.L7_FORTUNATE, TestimonyKey.L7_MALIFIC_DEBILITY),
+        2: (TestimonyKey.L2_FORTUNATE, TestimonyKey.L2_MALIFIC_DEBILITY),
+        8: (TestimonyKey.L8_FORTUNATE, TestimonyKey.L8_MALIFIC_DEBILITY),
+        5: (TestimonyKey.L5_FORTUNATE, TestimonyKey.L5_MALIFIC_DEBILITY),
+    }
+    benefics = {Planet.JUPITER, Planet.VENUS}
+    malefics = {Planet.MARS, Planet.SATURN}
+    for house, (pos_key, neg_key) in house_map.items():
+        ruler = chart.house_rulers.get(house)
+        if not ruler:
+            continue
+        position = chart.planets.get(ruler)
+        if not position:
+            continue
+        if ruler in benefics or position.dignity_score >= 5:
+            primitives.append(pos_key)
+        if ruler in malefics or position.dignity_score <= -5:
+            primitives.append(neg_key)
+
     return primitives
 
 

--- a/backend/horary_engine/polarity_weights.py
+++ b/backend/horary_engine/polarity_weights.py
@@ -23,6 +23,14 @@ class TestimonyKey(Enum):
     MOON_APPLYING_OPPOSITION_L1 = "moon_applying_opposition_l1"
     MOON_APPLYING_OPPOSITION_L7 = "moon_applying_opposition_l7"
     L10_FORTUNATE = "l10_fortunate"
+    L7_FORTUNATE = "l7_fortunate"
+    L7_MALIFIC_DEBILITY = "l7_malific_debility"
+    L2_FORTUNATE = "l2_fortunate"
+    L2_MALIFIC_DEBILITY = "l2_malific_debility"
+    L8_FORTUNATE = "l8_fortunate"
+    L8_MALIFIC_DEBILITY = "l8_malific_debility"
+    L5_FORTUNATE = "l5_fortunate"
+    L5_MALIFIC_DEBILITY = "l5_malific_debility"
     PERFECTION_DIRECT = "perfection_direct"
     PERFECTION_TRANSLATION_OF_LIGHT = "perfection_translation_of_light"
     PERFECTION_COLLECTION_OF_LIGHT = "perfection_collection_of_light"
@@ -49,6 +57,14 @@ POLARITY_TABLE: dict[TestimonyKey, Polarity] = {
     TestimonyKey.MOON_APPLYING_OPPOSITION_L7: Polarity.NEGATIVE,
     # Fortunate outcome promised by L10
     TestimonyKey.L10_FORTUNATE: Polarity.POSITIVE,
+    TestimonyKey.L7_FORTUNATE: Polarity.POSITIVE,
+    TestimonyKey.L7_MALIFIC_DEBILITY: Polarity.NEGATIVE,
+    TestimonyKey.L2_FORTUNATE: Polarity.POSITIVE,
+    TestimonyKey.L2_MALIFIC_DEBILITY: Polarity.NEGATIVE,
+    TestimonyKey.L8_FORTUNATE: Polarity.POSITIVE,
+    TestimonyKey.L8_MALIFIC_DEBILITY: Polarity.NEGATIVE,
+    TestimonyKey.L5_FORTUNATE: Polarity.POSITIVE,
+    TestimonyKey.L5_MALIFIC_DEBILITY: Polarity.NEGATIVE,
     # Perfection testimonies are positive by default
     TestimonyKey.PERFECTION_DIRECT: Polarity.POSITIVE,
     TestimonyKey.PERFECTION_TRANSLATION_OF_LIGHT: Polarity.POSITIVE,
@@ -68,6 +84,14 @@ WEIGHT_TABLE: dict[TestimonyKey, float] = {
     TestimonyKey.MOON_APPLYING_OPPOSITION_L1: 1.0,
     TestimonyKey.MOON_APPLYING_OPPOSITION_L7: 1.0,
     TestimonyKey.L10_FORTUNATE: 1.0,
+    TestimonyKey.L7_FORTUNATE: 1.0,
+    TestimonyKey.L7_MALIFIC_DEBILITY: 1.0,
+    TestimonyKey.L2_FORTUNATE: 1.0,
+    TestimonyKey.L2_MALIFIC_DEBILITY: 1.0,
+    TestimonyKey.L8_FORTUNATE: 1.0,
+    TestimonyKey.L8_MALIFIC_DEBILITY: 1.0,
+    TestimonyKey.L5_FORTUNATE: 1.0,
+    TestimonyKey.L5_MALIFIC_DEBILITY: 1.0,
     TestimonyKey.PERFECTION_DIRECT: 1.0,
     TestimonyKey.PERFECTION_TRANSLATION_OF_LIGHT: 1.0,
     TestimonyKey.PERFECTION_COLLECTION_OF_LIGHT: 1.0,
@@ -82,11 +106,27 @@ FAMILY_TABLE: dict[TestimonyKey, str] = {
     TestimonyKey.PERFECTION_DIRECT: "perfection",
     TestimonyKey.PERFECTION_TRANSLATION_OF_LIGHT: "perfection",
     TestimonyKey.PERFECTION_COLLECTION_OF_LIGHT: "perfection",
+    TestimonyKey.L7_FORTUNATE: "l7_condition",
+    TestimonyKey.L7_MALIFIC_DEBILITY: "l7_condition",
+    TestimonyKey.L2_FORTUNATE: "l2_condition",
+    TestimonyKey.L2_MALIFIC_DEBILITY: "l2_condition",
+    TestimonyKey.L8_FORTUNATE: "l8_condition",
+    TestimonyKey.L8_MALIFIC_DEBILITY: "l8_condition",
+    TestimonyKey.L5_FORTUNATE: "l5_condition",
+    TestimonyKey.L5_MALIFIC_DEBILITY: "l5_condition",
 }
 
 KIND_TABLE: dict[TestimonyKey, str] = {
     TestimonyKey.PERFECTION_DIRECT: "direct",
     TestimonyKey.PERFECTION_TRANSLATION_OF_LIGHT: "tol",
     TestimonyKey.PERFECTION_COLLECTION_OF_LIGHT: "col",
+    TestimonyKey.L7_FORTUNATE: "l7",
+    TestimonyKey.L7_MALIFIC_DEBILITY: "l7",
+    TestimonyKey.L2_FORTUNATE: "l2",
+    TestimonyKey.L2_MALIFIC_DEBILITY: "l2",
+    TestimonyKey.L8_FORTUNATE: "l8",
+    TestimonyKey.L8_MALIFIC_DEBILITY: "l8",
+    TestimonyKey.L5_FORTUNATE: "l5",
+    TestimonyKey.L5_MALIFIC_DEBILITY: "l5",
 }
 

--- a/backend/tests/test_category_tokens.py
+++ b/backend/tests/test_category_tokens.py
@@ -1,0 +1,114 @@
+import datetime
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+sys.path.append(str(ROOT))
+sys.path.append(str(ROOT / "backend"))
+
+from horary_engine.polarity_weights import TestimonyKey
+from horary_engine.aggregator import aggregate
+from horary_engine.rationale import build_rationale
+from horary_engine.polarity import Polarity
+from horary_engine.engine import extract_testimonies
+from models import Planet, PlanetPosition, HoraryChart, Sign
+
+
+def _make_pos(planet: Planet, dignity: int = 0) -> PlanetPosition:
+    return PlanetPosition(
+        planet=planet,
+        longitude=0.0,
+        latitude=0.0,
+        house=1,
+        sign=Sign.ARIES,
+        dignity_score=dignity,
+        retrograde=False,
+        speed=1.0,
+    )
+
+
+def _chart_one() -> HoraryChart:
+    planets = {
+        Planet.VENUS: _make_pos(Planet.VENUS, dignity=5),
+        Planet.MARS: _make_pos(Planet.MARS, dignity=0),
+        Planet.JUPITER: _make_pos(Planet.JUPITER, dignity=5),
+        Planet.SATURN: _make_pos(Planet.SATURN, dignity=-5),
+    }
+    dt = datetime.datetime(2024, 1, 1)
+    return HoraryChart(
+        date_time=dt,
+        date_time_utc=dt,
+        timezone_info="UTC",
+        location=(0.0, 0.0),
+        location_name="Test",
+        planets=planets,
+        aspects=[],
+        houses=[0.0] * 12,
+        house_rulers={7: Planet.VENUS, 2: Planet.MARS, 5: Planet.JUPITER, 8: Planet.SATURN},
+        ascendant=0.0,
+        midheaven=0.0,
+    )
+
+
+def _chart_two() -> HoraryChart:
+    planets = {
+        Planet.SATURN: _make_pos(Planet.SATURN, dignity=-5),
+        Planet.VENUS: _make_pos(Planet.VENUS, dignity=5),
+        Planet.JUPITER: _make_pos(Planet.JUPITER, dignity=5),
+        Planet.MARS: _make_pos(Planet.MARS, dignity=0),
+    }
+    dt = datetime.datetime(2024, 1, 1)
+    return HoraryChart(
+        date_time=dt,
+        date_time_utc=dt,
+        timezone_info="UTC",
+        location=(0.0, 0.0),
+        location_name="Test",
+        planets=planets,
+        aspects=[],
+        houses=[0.0] * 12,
+        house_rulers={7: Planet.SATURN, 2: Planet.VENUS, 5: Planet.SATURN, 8: Planet.JUPITER},
+        ascendant=0.0,
+        midheaven=0.0,
+    )
+
+
+def test_category_tokens_scoring_and_rationale():
+    for token, polarity in [
+        (TestimonyKey.L7_FORTUNATE, Polarity.POSITIVE),
+        (TestimonyKey.L7_MALIFIC_DEBILITY, Polarity.NEGATIVE),
+        (TestimonyKey.L2_FORTUNATE, Polarity.POSITIVE),
+        (TestimonyKey.L2_MALIFIC_DEBILITY, Polarity.NEGATIVE),
+        (TestimonyKey.L8_FORTUNATE, Polarity.POSITIVE),
+        (TestimonyKey.L8_MALIFIC_DEBILITY, Polarity.NEGATIVE),
+        (TestimonyKey.L5_FORTUNATE, Polarity.POSITIVE),
+        (TestimonyKey.L5_MALIFIC_DEBILITY, Polarity.NEGATIVE),
+    ]:
+        score, ledger = aggregate([token])
+        entry = ledger[0]
+        assert entry["polarity"] is polarity
+        if polarity is Polarity.POSITIVE:
+            assert entry["delta_yes"] == 1.0
+        else:
+            assert entry["delta_no"] == 1.0
+        rationale = build_rationale(ledger)
+        sign = "+" if polarity is Polarity.POSITIVE else "-"
+        assert f"{token.value} ({sign}1.0)" in rationale
+
+
+def test_extract_testimonies_emits_category_tokens():
+    chart = _chart_one()
+    primitives = extract_testimonies(chart, {})
+    assert TestimonyKey.L7_FORTUNATE in primitives
+    assert TestimonyKey.L2_MALIFIC_DEBILITY in primitives
+    assert TestimonyKey.L5_FORTUNATE in primitives
+    assert TestimonyKey.L8_MALIFIC_DEBILITY in primitives
+
+
+def test_extract_testimonies_emits_inverse_tokens():
+    chart = _chart_two()
+    primitives = extract_testimonies(chart, {})
+    assert TestimonyKey.L7_MALIFIC_DEBILITY in primitives
+    assert TestimonyKey.L2_FORTUNATE in primitives
+    assert TestimonyKey.L5_MALIFIC_DEBILITY in primitives
+    assert TestimonyKey.L8_FORTUNATE in primitives


### PR DESCRIPTION
## Summary
- add TestimonyKey tokens for relationship, money/funding and gambling house lords
- weight and polarities for new tokens and group by house
- emit fortune/debility tokens based on house lord and dignity
- test token scoring, rationale output and extraction logic

## Testing
- `pytest backend/tests/test_category_tokens.py -q`
- `pytest -q` *(fails: FileNotFoundError: will I win the lottery.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a6d201ae288324a05639d5b8b0ebf9