### PR TITLE
Map testimony tokens to rule weights

### DIFF
--- a/backend/horary_engine/polarity_weights.py
+++ b/backend/horary_engine/polarity_weights.py
@@ -34,6 +34,25 @@ class TestimonyKey(Enum):
 TestimonyKey.__test__ = False
 
 
+# Mapping of testimony tokens to rule identifiers used for weight lookup
+TOKEN_RULE_MAP: dict[TestimonyKey, str] = {
+    TestimonyKey.MOON_APPLYING_TRINE_EXAMINER_SUN: "M1",
+    TestimonyKey.MOON_APPLYING_SQUARE_EXAMINER_SUN: "M2",
+    TestimonyKey.MOON_APPLYING_SEXTILE_EXAMINER_SUN: "M3",
+    TestimonyKey.MOON_APPLYING_SEXTILE_L1: "M4",
+    TestimonyKey.MOON_APPLYING_SEXTILE_L7: "M5",
+    TestimonyKey.MOON_APPLYING_OPPOSITION_EXAMINER_SUN: "M6",
+    TestimonyKey.MOON_APPLYING_OPPOSITION_L1: "M7",
+    TestimonyKey.MOON_APPLYING_OPPOSITION_L7: "M8",
+    TestimonyKey.L10_FORTUNATE: "F1",
+    TestimonyKey.PERFECTION_DIRECT: "P1",
+    TestimonyKey.PERFECTION_TRANSLATION_OF_LIGHT: "P2",
+    TestimonyKey.PERFECTION_COLLECTION_OF_LIGHT: "P3",
+    TestimonyKey.ESSENTIAL_DETRIMENT: "MOD2",
+    TestimonyKey.ACCIDENTAL_RETROGRADE: "MOD3",
+}
+
+
 POLARITY_TABLE: dict[TestimonyKey, Polarity] = {
     # Favorable Moon applying trine to the examiner (Sun in education questions)
     TestimonyKey.MOON_APPLYING_TRINE_EXAMINER_SUN: Polarity.POSITIVE,
@@ -59,21 +78,7 @@ POLARITY_TABLE: dict[TestimonyKey, Polarity] = {
 }
 
 WEIGHT_TABLE: dict[TestimonyKey, float] = {
-    TestimonyKey.MOON_APPLYING_TRINE_EXAMINER_SUN: 1.0,
-    TestimonyKey.MOON_APPLYING_SQUARE_EXAMINER_SUN: 1.0,
-    TestimonyKey.MOON_APPLYING_SEXTILE_EXAMINER_SUN: 1.0,
-    TestimonyKey.MOON_APPLYING_SEXTILE_L1: 1.0,
-    TestimonyKey.MOON_APPLYING_SEXTILE_L7: 1.0,
-    TestimonyKey.MOON_APPLYING_OPPOSITION_EXAMINER_SUN: 1.0,
-    TestimonyKey.MOON_APPLYING_OPPOSITION_L1: 1.0,
-    TestimonyKey.MOON_APPLYING_OPPOSITION_L7: 1.0,
-    TestimonyKey.L10_FORTUNATE: 1.0,
-    TestimonyKey.PERFECTION_DIRECT: 1.0,
-    TestimonyKey.PERFECTION_TRANSLATION_OF_LIGHT: 1.0,
-    TestimonyKey.PERFECTION_COLLECTION_OF_LIGHT: 1.0,
-    # Debility weights sourced from rule pack
-    TestimonyKey.ESSENTIAL_DETRIMENT: abs(get_rule_weight("MOD2")),
-    TestimonyKey.ACCIDENTAL_RETROGRADE: abs(get_rule_weight("MOD3")),
+    token: abs(get_rule_weight(rule_id)) for token, rule_id in TOKEN_RULE_MAP.items()
 }
 
 

--- a/backend/rules_lilly_general_v1.yaml
+++ b/backend/rules_lilly_general_v1.yaml
@@ -23,6 +23,10 @@ rules:
     tier: perfection
     description: Translation of light
     weight: 2.0
+  - id: P3
+    tier: perfection
+    description: Collection of light
+    weight: 2.0
   - id: S1
     tier: special_topics
     description: Education overrides
@@ -31,14 +35,42 @@ rules:
     tier: special_topics
     description: Medical exceptions
     weight: 1.5
+  - id: F1
+    tier: special_topics
+    description: L10 fortunate
+    weight: 1.7
   - id: M1
     tier: moon
     description: Moon trine Sun
     weight: 1.8
   - id: M2
     tier: moon
-    description: Moon square Saturn
+    description: Moon square Sun
     weight: -2.2
+  - id: M3
+    tier: moon
+    description: Moon sextile Sun
+    weight: 1.2
+  - id: M4
+    tier: moon
+    description: Moon sextile L1
+    weight: 1.1
+  - id: M5
+    tier: moon
+    description: Moon sextile L7
+    weight: 1.1
+  - id: M6
+    tier: moon
+    description: Moon opposition Sun
+    weight: -1.4
+  - id: M7
+    tier: moon
+    description: Moon opposition L1
+    weight: -1.3
+  - id: M8
+    tier: moon
+    description: Moon opposition L7
+    weight: -1.2
   - id: MOD1
     tier: modifiers
     description: Reception boost

--- a/backend/tests/test_solar_aggregator.py
+++ b/backend/tests/test_solar_aggregator.py
@@ -7,6 +7,7 @@ sys.path.append(str(ROOT / "backend"))
 
 from horary_engine.dsl import role_importance, Moon, L1, L10
 from horary_engine.polarity_weights import TestimonyKey
+from rule_engine import get_rule_weight
 from horary_engine.solar_aggregator import aggregate as solar_aggregate
 from horary_engine.aggregator import aggregate as legacy_aggregate
 
@@ -17,8 +18,10 @@ def test_role_importance_scales_weights():
         TestimonyKey.MOON_APPLYING_TRINE_EXAMINER_SUN,
     ]
     score, ledger = solar_aggregate(testimonies)
-    assert score == 0.7
-    assert ledger[0]["weight"] == 0.7
+    base = abs(get_rule_weight("M1"))
+    expected = base * 0.7
+    assert score == expected
+    assert ledger[0]["weight"] == expected
 
 
 def test_legacy_and_solar_equal_without_importance():
@@ -45,5 +48,7 @@ def test_role_matching_uses_delimiters():
         TestimonyKey.L10_FORTUNATE,
     ]
     score, ledger = solar_aggregate(testimonies)
-    assert score == 2.0
-    assert ledger[0]["weight"] == 2.0
+    base = abs(get_rule_weight("F1"))
+    expected = base * 2.0
+    assert score == expected
+    assert ledger[0]["weight"] == expected


### PR DESCRIPTION
## Summary
- Map `TestimonyKey` entries to rule identifiers and derive weights from rule pack
- Extend rule pack with weights for Moon sextile/opposition, L10 fortunate, and collection of light
- Update tests to verify dynamic weight loading and role importance scaling

## Testing
- `pytest backend/tests/test_debility_tokens.py backend/tests/test_moon_aspects_tokens.py backend/tests/test_solar_aggregator.py`

------
https://chatgpt.com/codex/tasks/task_e_68a6d2d4be7c8324aa18005c3b0ede88