### PR TITLE
Make role importance configurable

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -14,3 +14,23 @@ configuration files, set the `HORARY_USE_DSL` environment variable to
 `false`. The `evaluate_chart` function also accepts a `use_dsl` argument
 which callers can populate from a query parameter or HTTP header to
 switch modes dynamically.
+
+### Role importance
+
+The DSL aggregator supports configurable weighting for key roles via the
+`aggregator.role_importance` section of `horary_constants.yaml`. These
+factors scale the contribution of testimonies involving a role. Default
+weights:
+
+```yaml
+aggregator:
+  role_importance:
+    L1: 1.0   # Querent
+    LQ: 1.0   # Quesited
+    Moon: 0.7 # Moon baseline
+    L10: 1.0  # Tenth house/examiner
+    L3: 1.0   # Third house/messenger
+```
+
+Custom projects can adjust these values to tune the baseline importance
+of each role.

--- a/backend/evaluate_chart.py
+++ b/backend/evaluate_chart.py
@@ -61,11 +61,21 @@ def evaluate_chart(
         from horary_engine.solar_aggregator import aggregate as aggregator_fn
 
         testimonies = [
-            role_importance(L1, 1.0),
-            role_importance(LQ, 1.0),
-            role_importance(Moon, 0.7),
-            role_importance(L10, 1.0),
-            role_importance(L3, 1.0),
+            role_importance(
+                L1, cfg().get("aggregator.role_importance.L1", 1.0)
+            ),
+            role_importance(
+                LQ, cfg().get("aggregator.role_importance.LQ", 1.0)
+            ),
+            role_importance(
+                Moon, cfg().get("aggregator.role_importance.Moon", 0.7)
+            ),
+            role_importance(
+                L10, cfg().get("aggregator.role_importance.L10", 1.0)
+            ),
+            role_importance(
+                L3, cfg().get("aggregator.role_importance.L3", 1.0)
+            ),
             *testimonies,
         ]
     else:

--- a/backend/horary_constants.yaml
+++ b/backend/horary_constants.yaml
@@ -6,6 +6,12 @@ aggregator:
   # environment variable to "false" to fall back to the legacy aggregation
   # logic without editing this file.
   use_dsl: true
+  role_importance:
+    L1: 1.0   # Querent significator
+    LQ: 1.0   # Quesited significator
+    Moon: 0.7 # Baseline weight for the Moon
+    L10: 1.0  # Tenth house/examiner significator
+    L3: 1.0   # Third house/messenger significator
 
 timing:
   # Timing calculation parameters

--- a/backend/tests/test_evaluate_chart_role_importance.py
+++ b/backend/tests/test_evaluate_chart_role_importance.py
@@ -1,0 +1,48 @@
+from pathlib import Path
+import sys
+
+ROOT = Path(__file__).resolve().parents[2]
+sys.path.append(str(ROOT))
+sys.path.append(str(ROOT / "backend"))
+
+import evaluate_chart
+from horary_engine.polarity_weights import TestimonyKey
+
+
+class DummyConfig:
+    def __init__(self, data):
+        self.data = data
+
+    def get(self, key, default=None):
+        value = self.data
+        for part in key.split('.'):
+            if isinstance(value, dict) and part in value:
+                value = value[part]
+            else:
+                return default
+        return value
+
+
+def test_evaluate_chart_applies_custom_role_importance(monkeypatch):
+    cfg_data = {
+        "aggregator": {
+            "use_dsl": True,
+            "role_importance": {
+                "L1": 1.0,
+                "LQ": 1.0,
+                "Moon": 0.7,
+                "L10": 2.0,
+                "L3": 1.0,
+            },
+        }
+    }
+    monkeypatch.setattr(evaluate_chart, "cfg", lambda: DummyConfig(cfg_data))
+    monkeypatch.setattr(evaluate_chart, "get_contract", lambda category: {})
+    monkeypatch.setattr(
+        evaluate_chart, "extract_testimonies", lambda chart, contract: [TestimonyKey.L10_FORTUNATE]
+    )
+
+    result = evaluate_chart.evaluate_chart({}, use_dsl=None)
+    ledger = result["ledger"]
+    assert ledger[0]["weight"] == 2.0
+    assert ledger[0]["role_factor"] == 2.0


### PR DESCRIPTION
## Summary
- allow configuring baseline weights for key roles in `horary_constants.yaml`
- reference configuration from `evaluate_chart` when seeding role importance
- document new settings and add regression test

## Testing
- `python -m pytest backend/tests/test_evaluate_chart_role_importance.py backend/tests/test_solar_aggregator.py`
- `python -m pytest backend/tests` *(fails: FileNotFoundError: [Errno 2] No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68a6da46a33483248de9188da2b9aa39