### PR TITLE
feat: map tokens to rule weights

### DIFF
--- a/backend/horary_engine/polarity_weights.py
+++ b/backend/horary_engine/polarity_weights.py
@@ -74,30 +74,35 @@ POLARITY_TABLE: dict[TestimonyKey, Polarity] = {
     TestimonyKey.ACCIDENTAL_RETROGRADE: Polarity.NEGATIVE,
 }
 
+# Mapping of tokens to rule identifiers for dynamic weight resolution
+TOKEN_RULE_MAP: dict[TestimonyKey, str] = {
+    TestimonyKey.MOON_APPLYING_TRINE_EXAMINER_SUN: "M1",
+    TestimonyKey.MOON_APPLYING_SQUARE_EXAMINER_SUN: "M3",
+    TestimonyKey.MOON_APPLYING_SEXTILE_EXAMINER_SUN: "M4",
+    TestimonyKey.MOON_APPLYING_SEXTILE_L1: "M5",
+    TestimonyKey.MOON_APPLYING_SEXTILE_L7: "M6",
+    TestimonyKey.MOON_APPLYING_OPPOSITION_EXAMINER_SUN: "M7",
+    TestimonyKey.MOON_APPLYING_OPPOSITION_L1: "M8",
+    TestimonyKey.MOON_APPLYING_OPPOSITION_L7: "M9",
+    TestimonyKey.L10_FORTUNATE: "LC1",
+    TestimonyKey.L7_FORTUNATE: "LC2",
+    TestimonyKey.L7_MALIFIC_DEBILITY: "LC3",
+    TestimonyKey.L2_FORTUNATE: "LC4",
+    TestimonyKey.L2_MALIFIC_DEBILITY: "LC5",
+    TestimonyKey.L8_FORTUNATE: "LC6",
+    TestimonyKey.L8_MALIFIC_DEBILITY: "LC7",
+    TestimonyKey.L5_FORTUNATE: "LC8",
+    TestimonyKey.L5_MALIFIC_DEBILITY: "LC9",
+    TestimonyKey.PERFECTION_DIRECT: "P1",
+    TestimonyKey.PERFECTION_TRANSLATION_OF_LIGHT: "P2",
+    TestimonyKey.PERFECTION_COLLECTION_OF_LIGHT: "P3",
+    TestimonyKey.ESSENTIAL_DETRIMENT: "MOD2",
+    TestimonyKey.ACCIDENTAL_RETROGRADE: "MOD3",
+}
+
 WEIGHT_TABLE: dict[TestimonyKey, float] = {
-    TestimonyKey.MOON_APPLYING_TRINE_EXAMINER_SUN: 1.0,
-    TestimonyKey.MOON_APPLYING_SQUARE_EXAMINER_SUN: 1.0,
-    TestimonyKey.MOON_APPLYING_SEXTILE_EXAMINER_SUN: 1.0,
-    TestimonyKey.MOON_APPLYING_SEXTILE_L1: 1.0,
-    TestimonyKey.MOON_APPLYING_SEXTILE_L7: 1.0,
-    TestimonyKey.MOON_APPLYING_OPPOSITION_EXAMINER_SUN: 1.0,
-    TestimonyKey.MOON_APPLYING_OPPOSITION_L1: 1.0,
-    TestimonyKey.MOON_APPLYING_OPPOSITION_L7: 1.0,
-    TestimonyKey.L10_FORTUNATE: 1.0,
-    TestimonyKey.L7_FORTUNATE: 1.0,
-    TestimonyKey.L7_MALIFIC_DEBILITY: 1.0,
-    TestimonyKey.L2_FORTUNATE: 1.0,
-    TestimonyKey.L2_MALIFIC_DEBILITY: 1.0,
-    TestimonyKey.L8_FORTUNATE: 1.0,
-    TestimonyKey.L8_MALIFIC_DEBILITY: 1.0,
-    TestimonyKey.L5_FORTUNATE: 1.0,
-    TestimonyKey.L5_MALIFIC_DEBILITY: 1.0,
-    TestimonyKey.PERFECTION_DIRECT: 1.0,
-    TestimonyKey.PERFECTION_TRANSLATION_OF_LIGHT: 1.0,
-    TestimonyKey.PERFECTION_COLLECTION_OF_LIGHT: 1.0,
-    # Debility weights sourced from rule pack
-    TestimonyKey.ESSENTIAL_DETRIMENT: abs(get_rule_weight("MOD2")),
-    TestimonyKey.ACCIDENTAL_RETROGRADE: abs(get_rule_weight("MOD3")),
+    token: abs(get_rule_weight(rule_id))
+    for token, rule_id in TOKEN_RULE_MAP.items()
 }
 
 

--- a/backend/rules_lilly_general_v1.yaml
+++ b/backend/rules_lilly_general_v1.yaml
@@ -59,3 +59,71 @@ rules:
     tier: thresholds
     description: Speed threshold
     weight: -1.0
+  - id: M3
+    tier: moon
+    description: Moon square Sun
+    weight: -1.0
+  - id: M4
+    tier: moon
+    description: Moon sextile Sun
+    weight: 1.0
+  - id: M5
+    tier: moon
+    description: Moon sextile L1
+    weight: 1.0
+  - id: M6
+    tier: moon
+    description: Moon sextile L7
+    weight: 1.0
+  - id: M7
+    tier: moon
+    description: Moon opposition Sun
+    weight: -1.0
+  - id: M8
+    tier: moon
+    description: Moon opposition L1
+    weight: -1.0
+  - id: M9
+    tier: moon
+    description: Moon opposition L7
+    weight: -1.0
+  - id: P3
+    tier: perfection
+    description: Collection of light
+    weight: 2.0
+  - id: LC1
+    tier: testimonies
+    description: L10 fortunate
+    weight: 1.0
+  - id: LC2
+    tier: testimonies
+    description: L7 fortunate
+    weight: 1.0
+  - id: LC3
+    tier: testimonies
+    description: L7 malefic debility
+    weight: -1.0
+  - id: LC4
+    tier: testimonies
+    description: L2 fortunate
+    weight: 1.0
+  - id: LC5
+    tier: testimonies
+    description: L2 malefic debility
+    weight: -1.0
+  - id: LC6
+    tier: testimonies
+    description: L8 fortunate
+    weight: 1.0
+  - id: LC7
+    tier: testimonies
+    description: L8 malefic debility
+    weight: -1.0
+  - id: LC8
+    tier: testimonies
+    description: L5 fortunate
+    weight: 1.0
+  - id: LC9
+    tier: testimonies
+    description: L5 malefic debility
+    weight: -1.0

--- a/backend/tests/test_solar_aggregator.py
+++ b/backend/tests/test_solar_aggregator.py
@@ -6,7 +6,8 @@ sys.path.append(str(ROOT))
 sys.path.append(str(ROOT / "backend"))
 
 from horary_engine.dsl import role_importance, Moon, L1, L10
-from horary_engine.polarity_weights import TestimonyKey
+from horary_engine.polarity_weights import TestimonyKey, TOKEN_RULE_MAP
+from rule_engine import get_rule_weight
 from horary_engine.solar_aggregator import aggregate as solar_aggregate
 from horary_engine.aggregator import aggregate as legacy_aggregate
 
@@ -17,8 +18,10 @@ def test_role_importance_scales_weights():
         TestimonyKey.MOON_APPLYING_TRINE_EXAMINER_SUN,
     ]
     score, ledger = solar_aggregate(testimonies)
-    assert score == 0.7
-    assert ledger[0]["weight"] == 0.7
+    base = abs(get_rule_weight(TOKEN_RULE_MAP[TestimonyKey.MOON_APPLYING_TRINE_EXAMINER_SUN]))
+    expected = base * 0.7
+    assert score == expected
+    assert ledger[0]["weight"] == expected
 
 
 def test_legacy_and_solar_equal_without_importance():

--- a/backend/tests/test_token_rule_weights.py
+++ b/backend/tests/test_token_rule_weights.py
@@ -1,0 +1,22 @@
+from pathlib import Path
+import sys
+import pytest
+
+ROOT = Path(__file__).resolve().parents[2]
+sys.path.append(str(ROOT))
+sys.path.append(str(ROOT / "backend"))
+
+from horary_engine.polarity_weights import TestimonyKey, TOKEN_RULE_MAP
+from horary_engine.aggregator import aggregate
+from rule_engine import get_rule_weight
+
+
+@pytest.mark.parametrize("token, rule_id", TOKEN_RULE_MAP.items())
+def test_token_weight_alignment(token: TestimonyKey, rule_id: str):
+    score, ledger = aggregate([token])
+    expected = get_rule_weight(rule_id)
+    assert score == expected
+    if expected >= 0:
+        assert ledger[0]["delta_yes"] == abs(expected)
+    else:
+        assert ledger[0]["delta_no"] == abs(expected)


### PR DESCRIPTION
## Summary
- map testimonies to rule IDs for dynamic weight lookup
- add rule weights for moon aspects, fortune/malefic tokens, and collection of light
- exercise dynamic weight loading across tokens in tests

## Testing
- `pytest` *(fails: FileNotFoundError for `will I win the lottery.json` in prohibition, scoring calibration, voc regression tests)*

------
https://chatgpt.com/codex/tasks/task_e_68a6dd30d21c8324a008ddc3441826fe