### PR TITLE
fix: avoid duplicate house for health questions

### DIFF
--- a/backend/question_analyzer.py
+++ b/backend/question_analyzer.py
@@ -533,10 +533,10 @@ class TraditionalHoraryQuestionAnalyzer:
                 
         elif question_type == Category.CAREER:
             houses.append(10)  # Career/reputation/profession
-            
+
         elif question_type == Category.HEALTH:
             # ENHANCED: Health questions use L1/L6 axis (self vs illness)
-            houses.extend([1, 6])  # L1 = self/vitality, L6 = illness/disease
+            houses.append(6)  # L1 already added; L6 = illness/disease
                 
         elif question_type == Category.LAWSUIT:
             houses.append(7)  # Open enemies/legal opponents

--- a/backend/tests/test_question_analyzer.py
+++ b/backend/tests/test_question_analyzer.py
@@ -6,7 +6,8 @@ sys.path.append(str(ROOT))
 sys.path.append(str(ROOT / "backend"))
 
 from question_analyzer import TraditionalHoraryQuestionAnalyzer
-from taxonomy import Category
+from taxonomy import Category, resolve
+from models import Planet
 
 
 def test_loan_application_question():
@@ -37,4 +38,22 @@ def test_relationship_houses():
     assert q_type is Category.RELATIONSHIP
     houses, _ = analyzer._determine_houses(question_lower, q_type, None)
     assert houses == [1, 7]
+
+
+def test_health_question_houses():
+    analyzer = TraditionalHoraryQuestionAnalyzer()
+    question = "Will I recover from this illness?"
+    result = analyzer.analyze_question(question)
+
+    assert result["question_type"] is Category.HEALTH
+    assert result["relevant_houses"] == [1, 6]
+
+    class DummyChart:
+        def __init__(self):
+            self.house_rulers = {1: Planet.SUN, 6: Planet.MARS}
+
+    chart = DummyChart()
+    resolved = resolve(chart, result["question_type"], manual_houses=result["relevant_houses"])
+    assert resolved["querent_house"] == 1
+    assert resolved["quesited_house"] == 6
 


### PR DESCRIPTION
## Summary
- prevent duplicate house 1 when determining health houses
- add regression test for health queries verifying houses 1 and 6 and taxonomy resolution

## Testing
- `pytest`
- `pytest backend/tests/test_question_analyzer.py::test_health_question_houses -q`


------
https://chatgpt.com/codex/tasks/task_e_68a6e2c152748324a98e8253362412d1