### PR TITLE
Refine aspect application and moiety orbs

### DIFF
--- a/backend/horary_constants.yaml
+++ b/backend/horary_constants.yaml
@@ -44,15 +44,17 @@ orbs:
   trine: 8.0
   opposition: 8.0
   
-  # Traditional planetary moieties (half-orbs) - Lilly/Bonatti values
+  # Traditional planetary orbs (degrees). Moiety-based calculations use half of these.
+  # Default moiety values:
+  #   Sun 15°, Moon 12°, Saturn/Jupiter 9°, Mars 7.5°, Venus 7.5°, Mercury 7°
   moieties:
-    Sun: 10.0      # Solar moiety (reduced for precision)
-    Moon: 8.0      # Lunar moiety (reduced from traditional 12.5)
-    Mercury: 4.0   # Mercurial moiety
-    Venus: 5.0     # Venusian moiety
-    Mars: 4.5      # Martial moiety
-    Jupiter: 6.0   # Jovial moiety
-    Saturn: 6.0    # Saturnian moiety
+    Sun: 15.0
+    Moon: 12.0
+    Mercury: 7.0
+    Venus: 7.5
+    Mars: 7.5
+    Jupiter: 9.0
+    Saturn: 9.0
   
   # Luminary orb bonuses
   sun_orb_bonus: 1.0


### PR DESCRIPTION
## Summary
- Derive signed longitudinal deltas for aspect calculations and respect faster planet motion
- Sum planetary half-orbs for moiety-based orbs and update default orb values
- Normalize separation logic across aspect timing helpers

## Testing
- `pytest -q` *(fails: FileNotFoundError: '/workspace/astrologyhoraryt/will I win the lottery.json')*
- `pytest backend/tests/test_aspect_timing.py -q`


------
https://chatgpt.com/codex/tasks/task_e_68a6eb0ce324832493992d1bff7cd6c4