### PR TITLE
Refine Moon VOC logic

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -47,6 +47,7 @@ from collections import defaultdict
 # UPDATED IMPORT: Use the new enhanced engine
 
 from horary_engine.engine import HoraryEngine, serialize_planet_with_solar
+from horary_engine.serialization import serialize_lunar_aspect
 from horary_engine.services.geolocation import LocationError
 from evaluate_chart import evaluate_chart
 from horary_engine.utils import token_to_string
@@ -1485,7 +1486,9 @@ def serialize_moon_debug(debug_data):
 
                 'degrees_left_in_sign': debug_data.get('void_result', {}).get('degrees_left_in_sign', 0),
 
-                'perfecting_aspects': debug_data.get('void_result', {}).get('perfecting_aspects', False)
+                'first_applying_aspect': serialize_lunar_aspect(
+                    debug_data.get('void_result', {}).get('first_applying_aspect')
+                ),
 
             },
 

--- a/backend/horary_engine/aspects.py
+++ b/backend/horary_engine/aspects.py
@@ -94,11 +94,21 @@ def calculate_moon_next_aspect(
     moon_speed = get_moon_speed(jd_ut)
     moon_days_to_exit = days_to_sign_exit(moon_pos.longitude, moon_speed)
 
+    # Only consider classical planets as targets
+    classical_targets = {
+        Planet.SUN,
+        Planet.MERCURY,
+        Planet.VENUS,
+        Planet.MARS,
+        Planet.JUPITER,
+        Planet.SATURN,
+    }
+
     # Find closest applying aspect
     applying_aspects: List[LunarAspect] = []
 
     for planet, planet_pos in planets.items():
-        if planet == Planet.MOON:
+        if planet not in classical_targets:
             continue
 
         # Calculate current separation using signed delta

--- a/backend/tests/test_cross_sign.py
+++ b/backend/tests/test_cross_sign.py
@@ -41,3 +41,29 @@ def test_cross_sign_perfection_disallowed():
     aspect = calculate_moon_next_aspect(planets, jd_ut=0.0, get_moon_speed=lambda _: 13.0)
     assert aspect is None
 
+
+def test_ignores_non_classical_targets():
+    planets = {
+        Planet.MOON: PlanetPosition(
+            planet=Planet.MOON,
+            longitude=18.0,
+            latitude=0.0,
+            house=1,
+            sign=Sign.ARIES,
+            dignity_score=0,
+            speed=13.0,
+        ),
+        Planet.ASC: PlanetPosition(
+            planet=Planet.ASC,
+            longitude=80.0,
+            latitude=0.0,
+            house=1,
+            sign=Sign.GEMINI,
+            dignity_score=0,
+            speed=0.0,
+        ),
+    }
+
+    aspect = calculate_moon_next_aspect(planets, jd_ut=0.0, get_moon_speed=lambda _: 13.0)
+    assert aspect is None
+


### PR DESCRIPTION
## Summary
- restrict lunar next-aspect search to classical planets and stop at sign exit
- drive void-of-course detection from next-aspect result and expose first applying aspect
- include first applying aspect in moon debug output and add regression test

## Testing
- `pytest` *(fails: FileNotFoundError for missing `will I win the lottery.json`)*

------
https://chatgpt.com/codex/tasks/task_e_68a6f168e49c8324a2e1caab0485b080