### PR TITLE
Restrict Sun-10th checks and prioritize L4 outcomes

### DIFF
--- a/backend/category_rules.py
+++ b/backend/category_rules.py
@@ -24,7 +24,7 @@ except ImportError:  # pragma: no cover
 DEFAULT_RULE: Dict[str, Any] = {
     "primary_significators": [],
     "allowed_turned_houses": {},
-    "outcome_houses": [],
+    "outcome_houses": [4],
     # By default consider general debilitation and cadent placement factors
     "scored_factors": ["debilitation", "cadent_significator"],
 }

--- a/backend/horary_constants.yaml
+++ b/backend/horary_constants.yaml
@@ -160,6 +160,7 @@ confidence:
 debilitation_penalties:
   dignity_threshold: -4
   l2: 15
+  l4: 15
   l11: 15
   cadent_significator: 5
 


### PR DESCRIPTION
## Summary
- Only check Sun applying to the 10th ruler when the question's default houses include house 10
- Use L4 as the default outcome house and apply penalties to any configured outcome houses
- Add configuration penalty for debilitated L4 rulers

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a706d204c48324bb12bbc5266ca9d9