### PR TITLE
Add dispatcher for DSL primitives to testimony tokens

### DIFF
--- a/backend/horary_engine/dsl_to_testimony.py
+++ b/backend/horary_engine/dsl_to_testimony.py
@@ -1,0 +1,93 @@
+"""Dispatch DSL primitives to testimony tokens with metadata."""
+from __future__ import annotations
+
+from typing import Any, Dict, List
+
+from .dsl import (
+    Aspect,
+    Translation,
+    Reception,
+    EssentialDignity,
+    Role,
+    Moon,
+    L10,
+)
+try:  # pragma: no cover - allow running as script
+    from ..models import Planet, Aspect as AspectType
+except ImportError:  # pragma: no cover
+    from models import Planet, Aspect as AspectType
+
+from .polarity_weights import TestimonyKey
+
+Dispatch = Dict[str, Any]
+
+
+def _collect_roles(obj: Any) -> List[str]:
+    roles: List[str] = []
+    for attr in ("actor", "receiver", "received", "translator", "from_actor", "to_actor", "actor1", "actor2"):
+        value = getattr(obj, attr, None)
+        if isinstance(value, Role):
+            roles.append(value.name.lower())
+    return roles
+
+
+def _dispatch_aspect(asp: Aspect) -> List[Dispatch]:
+    results: List[Dispatch] = []
+    if (
+        asp.actor1 == Moon
+        and asp.actor2 == Planet.SUN
+        and asp.aspect == AspectType.TRINE
+        and asp.applying
+    ):
+        results.append(
+            {
+                "key": TestimonyKey.MOON_APPLYING_TRINE_EXAMINER_SUN,
+                "house": None,
+                "factor": 1.0,
+                "roles": _collect_roles(asp),
+            }
+        )
+    return results
+
+
+def dispatch(obj: Any) -> List[Dispatch]:
+    """Return testimony mappings for a DSL primitive.
+
+    Unrecognized objects return an empty list allowing callers to pass through
+    non-DSL values unchanged.
+    """
+    if isinstance(obj, Aspect):
+        return _dispatch_aspect(obj)
+    if isinstance(obj, Translation):
+        return [
+            {
+                "key": TestimonyKey.PERFECTION_TRANSLATION_OF_LIGHT,
+                "house": None,
+                "factor": 1.0,
+                "roles": _collect_roles(obj),
+            }
+        ]
+    if isinstance(obj, Reception):
+        if obj.receiver == L10:
+            return [
+                {
+                    "key": TestimonyKey.L10_FORTUNATE,
+                    "house": 10,
+                    "factor": 1.0,
+                    "roles": _collect_roles(obj),
+                }
+            ]
+    if isinstance(obj, EssentialDignity):
+        if isinstance(obj.score, str) and obj.score.lower() == "detriment":
+            return [
+                {
+                    "key": TestimonyKey.ESSENTIAL_DETRIMENT,
+                    "house": None,
+                    "factor": 1.0,
+                    "roles": _collect_roles(obj),
+                }
+            ]
+    return []
+
+
+__all__ = ["dispatch"]

--- a/backend/tests/test_solar_aggregator.py
+++ b/backend/tests/test_solar_aggregator.py
@@ -1,15 +1,49 @@
 from pathlib import Path
 import sys
+import types
+import importlib.util
 
 ROOT = Path(__file__).resolve().parents[2]
-sys.path.append(str(ROOT))
+MODULE_DIR = ROOT / "backend" / "horary_engine"
 sys.path.append(str(ROOT / "backend"))
 
-from horary_engine.dsl import role_importance, Moon, L1, L10
-from horary_engine.polarity_weights import TestimonyKey, TOKEN_RULE_MAP
+# Create lightweight package to avoid heavy initialization
+pkg = types.ModuleType("horary_engine")
+pkg.__path__ = [str(MODULE_DIR)]
+sys.modules["horary_engine"] = pkg
+
+
+def _load(name: str):
+    spec = importlib.util.spec_from_file_location(
+        f"horary_engine.{name}", MODULE_DIR / f"{name}.py"
+    )
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[f"horary_engine.{name}"] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+polarity_weights = _load("polarity_weights")
+dsl = _load("dsl")
+_load("dsl_to_testimony")
+solar_aggregator_module = _load("solar_aggregator")
+aggregator_module = _load("aggregator")
+
+role_importance = dsl.role_importance
+Moon = dsl.Moon
+L1 = dsl.L1
+L10 = dsl.L10
+aspect = dsl.aspect
+translation = dsl.translation
+reception = dsl.reception
+
+from models import Planet, Aspect as AspectType
 from rule_engine import get_rule_weight
-from horary_engine.solar_aggregator import aggregate as solar_aggregate
-from horary_engine.aggregator import aggregate as legacy_aggregate
+
+TestimonyKey = polarity_weights.TestimonyKey
+TOKEN_RULE_MAP = polarity_weights.TOKEN_RULE_MAP
+solar_aggregate = solar_aggregator_module.aggregate
+legacy_aggregate = aggregator_module.aggregate
 
 
 def test_role_importance_scales_weights():
@@ -18,7 +52,9 @@ def test_role_importance_scales_weights():
         TestimonyKey.MOON_APPLYING_TRINE_EXAMINER_SUN,
     ]
     score, ledger = solar_aggregate(testimonies)
-    base = abs(get_rule_weight(TOKEN_RULE_MAP[TestimonyKey.MOON_APPLYING_TRINE_EXAMINER_SUN]))
+    base = abs(
+        get_rule_weight(TOKEN_RULE_MAP[TestimonyKey.MOON_APPLYING_TRINE_EXAMINER_SUN])
+    )
     expected = base * 0.7
     assert score == expected
     assert ledger[0]["weight"] == expected
@@ -34,10 +70,9 @@ def test_legacy_and_solar_equal_without_importance():
 def test_solar_scales_relative_to_legacy():
     tokens = [TestimonyKey.MOON_APPLYING_TRINE_EXAMINER_SUN]
     score_legacy, _ = legacy_aggregate(tokens)
-    score_solar, _ = solar_aggregate([
-        role_importance(Moon, 0.5),
-        TestimonyKey.MOON_APPLYING_TRINE_EXAMINER_SUN,
-    ])
+    score_solar, _ = solar_aggregate(
+        [role_importance(Moon, 0.5), TestimonyKey.MOON_APPLYING_TRINE_EXAMINER_SUN]
+    )
     assert score_solar == score_legacy * 0.5
 
 
@@ -50,3 +85,35 @@ def test_role_matching_uses_delimiters():
     score, ledger = solar_aggregate(testimonies)
     assert score == 2.0
     assert ledger[0]["weight"] == 2.0
+
+
+def test_dsl_aspect_dispatch():
+    testimonies = [aspect(Moon, Planet.SUN, AspectType.TRINE)]
+    score, ledger = solar_aggregate(testimonies)
+    expected = abs(
+        get_rule_weight(
+            TOKEN_RULE_MAP[TestimonyKey.MOON_APPLYING_TRINE_EXAMINER_SUN]
+        )
+    )
+    assert score == expected
+    assert ledger[0]["key"] is TestimonyKey.MOON_APPLYING_TRINE_EXAMINER_SUN
+
+
+def test_dsl_translation_dispatch():
+    testimonies = [translation(Moon, L1, Planet.SUN)]
+    score, ledger = solar_aggregate(testimonies)
+    expected = abs(
+        get_rule_weight(
+            TOKEN_RULE_MAP[TestimonyKey.PERFECTION_TRANSLATION_OF_LIGHT]
+        )
+    )
+    assert score == expected
+    assert ledger[0]["key"] is TestimonyKey.PERFECTION_TRANSLATION_OF_LIGHT
+
+
+def test_dsl_reception_dispatch():
+    testimonies = [reception(L10, L1, "mutual")]
+    score, ledger = solar_aggregate(testimonies)
+    expected = abs(get_rule_weight(TOKEN_RULE_MAP[TestimonyKey.L10_FORTUNATE]))
+    assert score == expected
+    assert ledger[0]["key"] is TestimonyKey.L10_FORTUNATE


### PR DESCRIPTION
## Summary
- map DSL primitives like Aspect, Translation, Reception and EssentialDignity to `TestimonyKey` tokens with metadata
- expand solar aggregator to convert DSL primitives before weighting and keep extra metadata
- add tests covering dispatch of Aspect, Translation and Reception primitives

## Testing
- `pytest tests/test_solar_aggregator.py -q`
- `pytest -q` *(fails: No module named 'geopy')*


------
https://chatgpt.com/codex/tasks/task_e_68a70cc36d488324a9a0cda895dd2924