### PR TITLE
Resolve role placeholders and propagate role weights

### DIFF
--- a/backend/evaluate_chart.py
+++ b/backend/evaluate_chart.py
@@ -81,7 +81,7 @@ def evaluate_chart(
     else:
         from horary_engine.aggregator import aggregate as aggregator_fn
 
-    score, ledger = aggregator_fn(testimonies)
+    score, ledger = aggregator_fn(testimonies, contract)
     # Surface ledger details for downstream inspection and debugging
     logger.info(
         "Contribution ledger: %s",


### PR DESCRIPTION
## Summary
- Resolve DSL Role placeholders against the significator contract and tag generated testimony tokens with those roles
- Apply RoleImportance factors to both enum and string testimony tokens via the solar aggregator
- Pass contracts through evaluation and expand test coverage

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a710315cd08324b4c45d6879f57488