### PR TITLE
Add translation and collection aspect tokens

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -34,3 +34,14 @@ aggregator:
 
 Custom projects can adjust these values to tune the baseline importance
 of each role.
+
+### Translation and Collection tokens
+
+Translations and collections of light now generate tokens that encode the
+aspect type and whether reception is present. The dispatcher produces
+names following the pattern `TRANSLATION_<ASPECT>_<WITH|WITHOUT>_RECEPTION`
+and `COLLECTION_<ASPECT>_<WITH|WITHOUT>_RECEPTION`. All such testimonies
+have a default absolute weight of `2.0`. Tokens with square or opposition
+aspects without reception count as negative testimony; all others are
+positive. Each dispatched entry also reports whether the aspect is
+applying via an `applying` flag in the ledger.

--- a/backend/horary_engine/dsl.py
+++ b/backend/horary_engine/dsl.py
@@ -60,10 +60,20 @@ class Translation:
     translator: Actor
     from_actor: Actor
     to_actor: Actor
+    aspect: AspectType = AspectType.CONJUNCTION
+    reception: bool = False
+    applying: bool = True
 
 
-def translation(translator: Actor, from_actor: Actor, to_actor: Actor) -> Translation:
-    return Translation(translator, from_actor, to_actor)
+def translation(
+    translator: Actor,
+    from_actor: Actor,
+    to_actor: Actor,
+    aspect: AspectType = AspectType.CONJUNCTION,
+    reception: bool = False,
+    applying: bool = True,
+) -> Translation:
+    return Translation(translator, from_actor, to_actor, aspect, reception, applying)
 
 
 @dataclass
@@ -73,10 +83,20 @@ class Collection:
     collector: Actor
     actor1: Actor
     actor2: Actor
+    aspect: AspectType = AspectType.CONJUNCTION
+    reception: bool = False
+    applying: bool = True
 
 
-def collection(collector: Actor, actor1: Actor, actor2: Actor) -> Collection:
-    return Collection(collector, actor1, actor2)
+def collection(
+    collector: Actor,
+    actor1: Actor,
+    actor2: Actor,
+    aspect: AspectType = AspectType.CONJUNCTION,
+    reception: bool = False,
+    applying: bool = True,
+) -> Collection:
+    return Collection(collector, actor1, actor2, aspect, reception, applying)
 
 
 @dataclass

--- a/backend/horary_engine/engine.py
+++ b/backend/horary_engine/engine.py
@@ -323,11 +323,25 @@ def extract_testimonies(chart: HoraryChart, contract: Dict[str, Planet]) -> List
             )
             if result.get("type") == "translation":
                 primitives.append(
-                    dsl_translation(result["translator"], sig1, sig2)
+                    dsl_translation(
+                        result["translator"],
+                        sig1,
+                        sig2,
+                        result.get("aspect"),
+                        result.get("reception", False),
+                        True,
+                    )
                 )
             elif result.get("type") == "collection":
                 primitives.append(
-                    dsl_collection(result["collector"], sig1, sig2)
+                    dsl_collection(
+                        result["collector"],
+                        sig1,
+                        sig2,
+                        result.get("aspect"),
+                        result.get("reception", False),
+                        True,
+                    )
                 )
             elif result.get("prohibited"):
                 primitives.append(

--- a/backend/horary_engine/polarity_weights.py
+++ b/backend/horary_engine/polarity_weights.py
@@ -34,6 +34,26 @@ class TestimonyKey(Enum):
     PERFECTION_DIRECT = "perfection_direct"
     PERFECTION_TRANSLATION_OF_LIGHT = "perfection_translation_of_light"
     PERFECTION_COLLECTION_OF_LIGHT = "perfection_collection_of_light"
+    TRANSLATION_CONJUNCTION_WITH_RECEPTION = "translation_conjunction_with_reception"
+    TRANSLATION_CONJUNCTION_WITHOUT_RECEPTION = "translation_conjunction_without_reception"
+    TRANSLATION_SEXTILE_WITH_RECEPTION = "translation_sextile_with_reception"
+    TRANSLATION_SEXTILE_WITHOUT_RECEPTION = "translation_sextile_without_reception"
+    TRANSLATION_SQUARE_WITH_RECEPTION = "translation_square_with_reception"
+    TRANSLATION_SQUARE_WITHOUT_RECEPTION = "translation_square_without_reception"
+    TRANSLATION_TRINE_WITH_RECEPTION = "translation_trine_with_reception"
+    TRANSLATION_TRINE_WITHOUT_RECEPTION = "translation_trine_without_reception"
+    TRANSLATION_OPPOSITION_WITH_RECEPTION = "translation_opposition_with_reception"
+    TRANSLATION_OPPOSITION_WITHOUT_RECEPTION = "translation_opposition_without_reception"
+    COLLECTION_CONJUNCTION_WITH_RECEPTION = "collection_conjunction_with_reception"
+    COLLECTION_CONJUNCTION_WITHOUT_RECEPTION = "collection_conjunction_without_reception"
+    COLLECTION_SEXTILE_WITH_RECEPTION = "collection_sextile_with_reception"
+    COLLECTION_SEXTILE_WITHOUT_RECEPTION = "collection_sextile_without_reception"
+    COLLECTION_SQUARE_WITH_RECEPTION = "collection_square_with_reception"
+    COLLECTION_SQUARE_WITHOUT_RECEPTION = "collection_square_without_reception"
+    COLLECTION_TRINE_WITH_RECEPTION = "collection_trine_with_reception"
+    COLLECTION_TRINE_WITHOUT_RECEPTION = "collection_trine_without_reception"
+    COLLECTION_OPPOSITION_WITH_RECEPTION = "collection_opposition_with_reception"
+    COLLECTION_OPPOSITION_WITHOUT_RECEPTION = "collection_opposition_without_reception"
     ESSENTIAL_DETRIMENT = "essential_detriment"
     ACCIDENTAL_RETROGRADE = "accidental_retrograde"
 
@@ -100,11 +120,6 @@ TOKEN_RULE_MAP: dict[TestimonyKey, str] = {
     TestimonyKey.ACCIDENTAL_RETROGRADE: "MOD3",
 }
 
-WEIGHT_TABLE: dict[TestimonyKey, float] = {
-    token: abs(get_rule_weight(rule_id))
-    for token, rule_id in TOKEN_RULE_MAP.items()
-}
-
 
 # ``family``/``kind`` tagging for group-based contribution control
 FAMILY_TABLE: dict[TestimonyKey, str] = {
@@ -133,5 +148,47 @@ KIND_TABLE: dict[TestimonyKey, str] = {
     TestimonyKey.L8_MALIFIC_DEBILITY: "l8",
     TestimonyKey.L5_FORTUNATE: "l5",
     TestimonyKey.L5_MALIFIC_DEBILITY: "l5",
+}
+
+# ---------------------------------------------------------------------------
+# Translation/Collection token configuration
+# ---------------------------------------------------------------------------
+
+ASPECTS = ["CONJUNCTION", "SEXTILE", "SQUARE", "TRINE", "OPPOSITION"]
+
+for aspect in ASPECTS:
+    t_with = getattr(TestimonyKey, f"TRANSLATION_{aspect}_WITH_RECEPTION")
+    t_without = getattr(TestimonyKey, f"TRANSLATION_{aspect}_WITHOUT_RECEPTION")
+    c_with = getattr(TestimonyKey, f"COLLECTION_{aspect}_WITH_RECEPTION")
+    c_without = getattr(TestimonyKey, f"COLLECTION_{aspect}_WITHOUT_RECEPTION")
+
+    # Translation tokens
+    POLARITY_TABLE[t_with] = Polarity.POSITIVE
+    POLARITY_TABLE[t_without] = (
+        Polarity.NEGATIVE if aspect in {"SQUARE", "OPPOSITION"} else Polarity.POSITIVE
+    )
+    TOKEN_RULE_MAP[t_with] = "P2"
+    TOKEN_RULE_MAP[t_without] = (
+        "P2_NEG" if POLARITY_TABLE[t_without] is Polarity.NEGATIVE else "P2"
+    )
+    FAMILY_TABLE[t_with] = FAMILY_TABLE[t_without] = "perfection"
+    KIND_TABLE[t_with] = KIND_TABLE[t_without] = "tol"
+
+    # Collection tokens
+    POLARITY_TABLE[c_with] = Polarity.POSITIVE
+    POLARITY_TABLE[c_without] = (
+        Polarity.NEGATIVE if aspect in {"SQUARE", "OPPOSITION"} else Polarity.POSITIVE
+    )
+    TOKEN_RULE_MAP[c_with] = "P3"
+    TOKEN_RULE_MAP[c_without] = (
+        "P3_NEG" if POLARITY_TABLE[c_without] is Polarity.NEGATIVE else "P3"
+    )
+    FAMILY_TABLE[c_with] = FAMILY_TABLE[c_without] = "perfection"
+    KIND_TABLE[c_with] = KIND_TABLE[c_without] = "col"
+
+
+# Weight table is derived from rule mappings
+WEIGHT_TABLE: dict[TestimonyKey, float] = {
+    token: abs(get_rule_weight(rule_id)) for token, rule_id in TOKEN_RULE_MAP.items()
 }
 

--- a/backend/rules_lilly_general_v1.yaml
+++ b/backend/rules_lilly_general_v1.yaml
@@ -23,6 +23,10 @@ rules:
     tier: perfection
     description: Translation of light
     weight: 2.0
+  - id: P2_NEG
+    tier: perfection
+    description: Translation of light (negative)
+    weight: -2.0
   - id: S1
     tier: special_topics
     description: Education overrides
@@ -91,6 +95,10 @@ rules:
     tier: perfection
     description: Collection of light
     weight: 2.0
+  - id: P3_NEG
+    tier: perfection
+    description: Collection of light (negative)
+    weight: -2.0
   - id: LC1
     tier: testimonies
     description: L10 fortunate

--- a/backend/tests/test_solar_aggregator.py
+++ b/backend/tests/test_solar_aggregator.py
@@ -13,6 +13,7 @@ LQ = dsl.LQ
 aspect = dsl.aspect
 translation = dsl.translation
 reception = dsl.reception
+collection = dsl.collection
 
 TestimonyKey = polarity_weights.TestimonyKey
 TOKEN_RULE_MAP = polarity_weights.TOKEN_RULE_MAP
@@ -72,16 +73,27 @@ def test_dsl_aspect_dispatch():
 
 
 def test_dsl_translation_dispatch():
-    testimonies = [translation(Moon, L1, Planet.SUN)]
+    testimonies = [
+        translation(Moon, L1, Planet.SUN, AspectType.SQUARE, True)
+    ]
     contract = {"querent": Planet.MERCURY}
     score, ledger = solar_aggregate(testimonies, contract)
-    expected = abs(
-        get_rule_weight(
-            TOKEN_RULE_MAP[TestimonyKey.PERFECTION_TRANSLATION_OF_LIGHT]
-        )
-    )
+    token = TestimonyKey.TRANSLATION_SQUARE_WITH_RECEPTION
+    expected = abs(get_rule_weight(TOKEN_RULE_MAP[token]))
     assert score == expected
-    assert ledger[0]["key"] is TestimonyKey.PERFECTION_TRANSLATION_OF_LIGHT
+    assert ledger[0]["key"] is token
+    assert ledger[0]["applying"] is True
+
+
+def test_dsl_collection_dispatch():
+    testimonies = [collection(Moon, L1, Planet.SUN, AspectType.TRINE)]
+    contract = {"querent": Planet.MERCURY}
+    score, ledger = solar_aggregate(testimonies, contract)
+    token = TestimonyKey.COLLECTION_TRINE_WITHOUT_RECEPTION
+    expected = abs(get_rule_weight(TOKEN_RULE_MAP[token]))
+    assert score == expected
+    assert ledger[0]["key"] is token
+    assert ledger[0]["applying"] is True
 
 
 def test_dsl_reception_dispatch():


### PR DESCRIPTION
## Summary
- dispatch Translation and Collection primitives into aspect/reception tokens
- register new tokens with polarity, weight, and rule mappings
- document translation/collection token patterns

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a715a7f1a48324a64559a3b3993310