### PR TITLE
feat: narrate reception and dignity primitives

### DIFF
--- a/backend/horary_engine/rationale.py
+++ b/backend/horary_engine/rationale.py
@@ -1,15 +1,31 @@
 """Utilities for turning a contribution ledger into human-readable text."""
 from __future__ import annotations
 
-from typing import List, Dict
+from typing import List, Dict, Any
 
 from .polarity import Polarity, polarity_sign
 from .polarity_weights import TestimonyKey
 from .utils import token_to_string
+from .dsl import Reception, EssentialDignity, AccidentalDignity, Role
+
+try:  # pragma: no cover - allow execution as script
+    from ..models import Planet
+except Exception:  # pragma: no cover
+    from models import Planet
+
+
+def _actor_name(actor: Any) -> str:
+    """Return a readable name for either a role or planet."""
+
+    if isinstance(actor, Role):
+        return actor.name
+    if isinstance(actor, Planet):
+        return actor.value
+    return str(actor)
 
 
 def build_rationale(
-    ledger: List[Dict[str, float | TestimonyKey | Polarity]]
+    ledger: List[Dict[str, float | TestimonyKey | Polarity | Any]]
 ) -> List[str]:
     """Create a rationale list from a contribution ledger.
 
@@ -17,6 +33,36 @@ def build_rationale(
     """
     result: List[str] = []
     for entry in ledger:
+        primitive = entry.get("primitive") or entry.get("key")
+
+        if isinstance(primitive, Reception):
+            receiver = _actor_name(primitive.receiver)
+            received = _actor_name(primitive.received)
+            dignity = "sign" if primitive.dignity == "domicile" else primitive.dignity
+            result.append(f"{receiver} receives {received} by {dignity}")
+            continue
+
+        if isinstance(primitive, EssentialDignity):
+            actor = _actor_name(primitive.actor)
+            score = primitive.score
+            if isinstance(score, str):
+                result.append(f"{actor} is in {score}")
+            else:
+                result.append(f"{actor} essential dignity {score}")
+            continue
+
+        if isinstance(primitive, AccidentalDignity):
+            actor = _actor_name(primitive.actor)
+            score = primitive.score
+            if isinstance(score, str):
+                if score.lower() == "retro":
+                    result.append(f"{actor} is retrograde")
+                else:
+                    result.append(f"{actor} {score}")
+            else:
+                result.append(f"{actor} accidental dignity {score}")
+            continue
+
         key = token_to_string(entry.get("key", ""))
         weight = entry.get("weight", 0.0)
         polarity = entry.get("polarity", Polarity.NEUTRAL)

--- a/backend/horary_engine/solar_aggregator.py
+++ b/backend/horary_engine/solar_aggregator.py
@@ -59,6 +59,7 @@ def aggregate(
 
     raw_items: List[TestimonyKey | str | RoleImportance] = []
     extra_info: Dict[TestimonyKey | str, Dict[str, Any]] = {}
+    unscored: List[Any] = []
     for raw in testimonies:
         dispatched = dsl_dispatch(raw, contract)
         if dispatched:
@@ -68,6 +69,7 @@ def aggregate(
                 extra_info[token] = {k: v for k, v in entry.items() if k != "key"}
         else:
             raw_items.append(raw)
+            unscored.append(raw)
 
     tokens, role_weights = _coerce(raw_items)
 
@@ -123,6 +125,18 @@ def aggregate(
         if token in extra_info:
             entry.update(extra_info[token])
         ledger.append(entry)
+
+    for obj in unscored:
+        ledger.append(
+            {
+                "key": obj,
+                "polarity": Polarity.NEUTRAL,
+                "weight": 0.0,
+                "delta_yes": 0.0,
+                "delta_no": 0.0,
+                "primitive": obj,
+            }
+        )
 
     total = total_yes - total_no
     return total, ledger

--- a/backend/tests/test_reception_rationale.py
+++ b/backend/tests/test_reception_rationale.py
@@ -1,0 +1,59 @@
+import datetime
+from pathlib import Path
+import sys
+
+
+ROOT = Path(__file__).resolve().parents[2]
+sys.path.append(str(ROOT))
+sys.path.append(str(ROOT / "backend"))
+
+from horary_engine.engine import extract_testimonies
+from horary_engine.solar_aggregator import aggregate
+from horary_engine.rationale import build_rationale
+from models import Planet, PlanetPosition, HoraryChart, Sign
+
+
+def _make_pos(planet: Planet, sign: Sign) -> PlanetPosition:
+    return PlanetPosition(
+        planet=planet,
+        longitude=sign.start_degree,
+        latitude=0.0,
+        house=1,
+        sign=sign,
+        dignity_score=0,
+        retrograde=False,
+        speed=1.0,
+    )
+
+
+def _make_chart() -> HoraryChart:
+    planets = {
+        Planet.MARS: _make_pos(Planet.MARS, Sign.TAURUS),
+        Planet.VENUS: _make_pos(Planet.VENUS, Sign.ARIES),
+        Planet.SUN: _make_pos(Planet.SUN, Sign.CANCER),
+    }
+    dt = datetime.datetime(2024, 1, 1)
+    return HoraryChart(
+        date_time=dt,
+        date_time_utc=dt,
+        timezone_info="UTC",
+        location=(0.0, 0.0),
+        location_name="Test",
+        planets=planets,
+        aspects=[],
+        houses=[i * 30.0 for i in range(12)],
+        house_rulers={},
+        ascendant=0.0,
+        midheaven=0.0,
+    )
+
+
+def test_mutual_reception_rationale():
+    chart = _make_chart()
+    contract = {"querent": Planet.MARS, "quesited": Planet.VENUS}
+    primitives = extract_testimonies(chart, contract)
+    score, ledger = aggregate(primitives, contract)
+    rationale = build_rationale(ledger)
+    assert any("Mars receives Venus" in line for line in rationale)
+    assert any("Venus receives Mars" in line for line in rationale)
+


### PR DESCRIPTION
## Summary
- narrate receptions, essential dignities and accidental dignities in rationale output
- retain unscored DSL primitives in solar aggregator ledger
- cover mutual reception rationale with a regression test

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a71f7dec248324a61b1b43aafdf5eb