### PR TITLE
Add DSL primitive serialization and API exposure

### DIFF
--- a/backend/tests/test_dsl_serialization_roundtrip.py
+++ b/backend/tests/test_dsl_serialization_roundtrip.py
@@ -1,0 +1,56 @@
+import sys
+from pathlib import Path
+import pytest
+
+ROOT = Path(__file__).resolve().parents[2]
+sys.path.append(str(ROOT))
+sys.path.append(str(ROOT / "backend"))
+
+from horary_engine.dsl import (
+    aspect,
+    translation,
+    collection,
+    prohibition,
+    refranation,
+    frustration,
+    abscission,
+    reception,
+    essential,
+    accidental,
+    moon_voc,
+    house,
+    role_importance,
+    L1,
+    LQ,
+)
+from models import Planet, Aspect as AspectType
+from horary_engine.serialization import serialize_primitive, deserialize_primitive
+
+PRIMITIVES = [
+    aspect(Planet.SUN, Planet.MOON, AspectType.TRINE),
+    translation(
+        Planet.MERCURY,
+        Planet.MARS,
+        Planet.VENUS,
+        AspectType.SEXTILE,
+        True,
+    ),
+    collection(Planet.JUPITER, L1, LQ, AspectType.CONJUNCTION, True),
+    prohibition(Planet.SATURN, L1, AspectType.SQUARE),
+    refranation(Planet.MARS, L1),
+    frustration(Planet.VENUS, L1, LQ),
+    abscission(Planet.JUPITER, Planet.MARS, Planet.SATURN),
+    reception(Planet.SUN, Planet.MOON, "exalt"),
+    essential(Planet.MARS, 5),
+    accidental(Planet.VENUS, "retro"),
+    moon_voc(True, "test"),
+    house(Planet.MERCURY, 3),
+    role_importance(L1, 1.2),
+]
+
+
+@pytest.mark.parametrize("primitive", PRIMITIVES)
+def test_round_trip_serialization(primitive):
+    data = serialize_primitive(primitive)
+    restored = deserialize_primitive(data)
+    assert restored == primitive


### PR DESCRIPTION
## Summary
- serialize and deserialize DSL primitives with concise JSON helpers
- expose serialized primitives via `dsl_primitives` in chart evaluation responses
- cover round-trip serialization for all DSL dataclasses in unit tests

## Testing
- `pytest backend/tests/test_dsl_serialization_roundtrip.py -q`
- `pytest backend/tests -q`


------
https://chatgpt.com/codex/tasks/task_e_68a726a365f48324bac33e8ee90718b0