### PR TITLE
Unify Moon applying/separating aspect logic

### DIFF
--- a/backend/horary_engine/aspects.py
+++ b/backend/horary_engine/aspects.py
@@ -50,7 +50,7 @@ def calculate_moon_last_aspect(
             if orb_diff <= max_orb * 1.5:
                 # Check if separating (Moon was closer recently)
                 if is_moon_separating_from_aspect(
-                    moon_pos, planet_pos, aspect_type, moon_speed
+                    moon_pos, planet_pos, aspect_type, jd_ut
                 ):
                     degrees_since_exact = orb_diff
                     relative_speed = moon_speed - planet_pos.speed
@@ -120,8 +120,8 @@ def calculate_moon_next_aspect(
             max_orb = aspect_type.orb
 
             if orb_diff <= max_orb:
-                if is_moon_applying_to_aspect(
-                    moon_pos, planet_pos, aspect_type, moon_speed
+                if is_applying_enhanced(
+                    moon_pos, planet_pos, aspect_type, jd_ut
                 ):
                     degrees_to_exact = orb_diff
                     relative_speed = moon_speed - planet_pos.speed
@@ -159,47 +159,33 @@ def calculate_moon_next_aspect(
     return None
 
 
-def _moon_orb_motion(
-    moon_pos: PlanetPosition,
-    planet_pos: PlanetPosition,
-    aspect: Aspect,
-    moon_speed: float,
-) -> float:
-    """Return the signed rate of change of the orb between the Moon and a planet.
-
-    Positive values mean the orb is widening (separating), negative values mean
-    the orb is narrowing (applying).
-    """
-
-    # Signed difference from exact aspect in range [-180, 180)
-    diff = (moon_pos.longitude - planet_pos.longitude - aspect.degrees + 180) % 360 - 180
-
-    # Relative speed between the Moon and the other planet
-    relative_speed = moon_speed - planet_pos.speed
-
-    return diff * relative_speed
-
-
 def is_moon_separating_from_aspect(
     moon_pos: PlanetPosition,
     planet_pos: PlanetPosition,
     aspect: Aspect,
-    moon_speed: float,
+    jd_ut: float,
 ) -> bool:
-    """Check if the Moon is separating from an aspect using analytic motion."""
+    """Thin wrapper around :func:`is_applying_enhanced` for backward compatibility."""
 
-    return _moon_orb_motion(moon_pos, planet_pos, aspect, moon_speed) > 0
+    if is_applying_enhanced(moon_pos, planet_pos, aspect, jd_ut):
+        return False
+
+    diff = (
+        moon_pos.longitude - planet_pos.longitude - aspect.degrees + 180
+    ) % 360 - 180
+    relative_speed = moon_pos.speed - planet_pos.speed
+    return diff * relative_speed > 0
 
 
 def is_moon_applying_to_aspect(
     moon_pos: PlanetPosition,
     planet_pos: PlanetPosition,
     aspect: Aspect,
-    moon_speed: float,
+    jd_ut: float,
 ) -> bool:
-    """Check if the Moon is applying to an aspect using analytic motion."""
+    """Thin wrapper around :func:`is_applying_enhanced` for backward compatibility."""
 
-    return _moon_orb_motion(moon_pos, planet_pos, aspect, moon_speed) < 0
+    return is_applying_enhanced(moon_pos, planet_pos, aspect, jd_ut)
 
 
 def format_timing_description(days: float) -> str:

--- a/backend/horary_engine/calculation/helpers.py
+++ b/backend/horary_engine/calculation/helpers.py
@@ -302,7 +302,8 @@ def check_aspect_separation_order(
     The previous implementation estimated the separation trend by looking one
     hour ahead. This fails for very slow or very fast planets. Instead we use
     the relative speed between the planets to analytically compute whether the
-    orb is widening or narrowing, similar to :func:`_moon_orb_motion`.
+    orb is widening or narrowing, using the same approach as
+    :func:`is_applying_enhanced`.
 
     Parameters
     ----------

--- a/backend/tests/test_moon_applying_sextile.py
+++ b/backend/tests/test_moon_applying_sextile.py
@@ -1,0 +1,64 @@
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+sys.path.append(str(ROOT))
+sys.path.append(str(ROOT / "backend"))
+
+try:
+    from ..horary_engine.aspects import (
+        calculate_enhanced_aspects,
+        calculate_moon_next_aspect,
+    )
+except ImportError:  # pragma: no cover
+    from horary_engine.aspects import (
+        calculate_enhanced_aspects,
+        calculate_moon_next_aspect,
+    )
+
+try:
+    from ..models import Aspect, Planet, PlanetPosition, Sign
+except ImportError:  # pragma: no cover
+    from models import Aspect, Planet, PlanetPosition, Sign
+
+
+def test_moon_sextile_mars_applying_consistency():
+    planets = {
+        Planet.MOON: PlanetPosition(
+            planet=Planet.MOON,
+            longitude=69.2,
+            latitude=0.0,
+            house=1,
+            sign=Sign.GEMINI,
+            dignity_score=0,
+            speed=13.0,
+        ),
+        Planet.MARS: PlanetPosition(
+            planet=Planet.MARS,
+            longitude=10.0,
+            latitude=0.0,
+            house=1,
+            sign=Sign.ARIES,
+            dignity_score=0,
+            speed=0.7,
+        ),
+    }
+
+    jd_ut = 0.0
+
+    # Enhanced aspects API
+    aspects = calculate_enhanced_aspects(planets, jd_ut)
+    moon_mars = next(
+        a for a in aspects if {a.planet1, a.planet2} == {Planet.MOON, Planet.MARS}
+    )
+    assert moon_mars.aspect == Aspect.SEXTILE
+    assert moon_mars.applying
+
+    # Moon considerations API
+    moon_next = calculate_moon_next_aspect(
+        planets, jd_ut, get_moon_speed=lambda _: 13.0
+    )
+    assert moon_next is not None
+    assert moon_next.planet == Planet.MARS
+    assert moon_next.aspect == Aspect.SEXTILE
+    assert moon_next.applying


### PR DESCRIPTION
## Summary
- Refactor Moon applying/separating helpers to delegate to the enhanced applying check.
- Use `is_applying_enhanced` in `calculate_moon_next_aspect` so considerations tab and enhanced aspects share logic.
- Add regression test ensuring both APIs mark a near-sextile Moon–Mars aspect as applying.

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a72e0508b88324bbbfa79e11305c4e