### PR TITLE
Fix retrograde aspect motion detection

### DIFF
--- a/backend/tests/test_aspect_timing.py
+++ b/backend/tests/test_aspect_timing.py
@@ -59,3 +59,11 @@ def test_fast_behind_slow_positive_time():
 
     t = calc._calculate_future_aspect_time(fast, slow, Aspect.CONJUNCTION, 0.0, 10)
     assert t > 0
+
+
+def test_mercury_rx_applying_to_venus():
+    mercury_rx = make_pos(Planet.MERCURY, 14.0, -1.2)
+    venus = make_pos(Planet.VENUS, 12.0, 1.0)
+
+    assert is_applying_enhanced(mercury_rx, venus, Aspect.CONJUNCTION, 0.0)
+    assert is_applying_enhanced(venus, mercury_rx, Aspect.CONJUNCTION, 0.0)


### PR DESCRIPTION
## Summary
- add `_orb_motion` for signed orb motion
- simplify `is_applying_enhanced` using orb motion and sign-exit check
- test Mercury retrograde applying to Venus

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a731d32d8483249faced2414726396