### PR TITLE
Expose cross-sign perfection flag for applying aspects

### DIFF
--- a/backend/horary_engine/serialization.py
+++ b/backend/horary_engine/serialization.py
@@ -128,6 +128,7 @@ def serialize_chart_for_frontend(
                 "aspect": aspect.aspect.display_name,
                 "orb": round(aspect.orb, 2),
                 "applying": aspect.applying,
+                "perfection_within_sign": aspect.perfection_within_sign,
                 "degrees_to_exact": round(aspect.degrees_to_exact, 2),
                 "exact_time": aspect.exact_time.isoformat() if aspect.exact_time else None,
             }

--- a/backend/models.py
+++ b/backend/models.py
@@ -109,6 +109,7 @@ class AspectInfo:
     aspect: Aspect
     orb: float
     applying: bool
+    perfection_within_sign: bool = True
     exact_time: Optional[datetime.datetime] = None
     degrees_to_exact: float = 0.0
 

--- a/backend/tests/test_aspect_timing.py
+++ b/backend/tests/test_aspect_timing.py
@@ -47,7 +47,7 @@ def test_moon_venus_conjunction_time_applying():
     t = calc._calculate_future_aspect_time(moon, venus, Aspect.CONJUNCTION, 0.0, 10)
     assert t is not None
     assert abs(t - 0.021) < 0.005
-    assert is_applying_enhanced(moon, venus, Aspect.CONJUNCTION, 0.0)
+    assert is_applying_enhanced(moon, venus, Aspect.CONJUNCTION, 0.0)[0]
 
 
 def test_fast_behind_slow_positive_time():
@@ -65,5 +65,16 @@ def test_mercury_rx_applying_to_venus():
     mercury_rx = make_pos(Planet.MERCURY, 14.0, -1.2)
     venus = make_pos(Planet.VENUS, 12.0, 1.0)
 
-    assert is_applying_enhanced(mercury_rx, venus, Aspect.CONJUNCTION, 0.0)
-    assert is_applying_enhanced(venus, mercury_rx, Aspect.CONJUNCTION, 0.0)
+    assert is_applying_enhanced(mercury_rx, venus, Aspect.CONJUNCTION, 0.0)[0]
+    assert is_applying_enhanced(venus, mercury_rx, Aspect.CONJUNCTION, 0.0)[0]
+
+
+def test_applying_cross_sign_flag():
+    venus = make_pos(Planet.VENUS, 115.0, 1.0)
+    saturn = make_pos(Planet.SATURN, 0.0, -0.05)
+
+    applying, within_sign = is_applying_enhanced(
+        venus, saturn, Aspect.OPPOSITION, 0.0
+    )
+    assert applying
+    assert not within_sign


### PR DESCRIPTION
## Summary
- decouple applying status from sign-exit checks in `is_applying_enhanced`
- surface `perfection_within_sign` metadata through aspect calculations and serialization
- test applying aspects that require a sign change

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a737038fb48324815aea79f20ae13d