### PR TITLE
Conditionally pass contract to aggregator

### DIFF
--- a/backend/evaluate_chart.py
+++ b/backend/evaluate_chart.py
@@ -99,7 +99,10 @@ def evaluate_chart(
         serialize_primitive(t) for t in testimonies if is_dataclass(t)
     ]
 
-    score, ledger = aggregator_fn(testimonies, contract)
+    if use_dsl:
+        score, ledger = aggregator_fn(testimonies, contract)
+    else:
+        score, ledger = aggregator_fn(testimonies)
     # Surface ledger details for downstream inspection and debugging
     logger.info(
         "Contribution ledger: %s",


### PR DESCRIPTION
## Summary
- Only pass `contract` to `aggregator_fn` when the DSL aggregator is used

## Testing
- `pytest backend/tests`


------
https://chatgpt.com/codex/tasks/task_e_68a7382b8204832498e1a8ad9d87a89a