### PR TITLE
Add partner healing category

### DIFF
--- a/backend/question_analyzer.py
+++ b/backend/question_analyzer.py
@@ -41,6 +41,7 @@ class TraditionalHoraryQuestionAnalyzer:
             Category.FUNDING: ["funding", "fund", "investment", "invest", "investor", "funding round", "seed", "series a", "series b", "venture capital", "vc", "angel", "capital", "raise money", "raise capital", "secure funding", "startup funding", "business loan", "loan", "loan application", "finance", "financial backing", "sponsor", "grant", "equity", "valuation"],
             Category.MONEY: ["money", "wealth", "rich", "profit", "gain", "debt", "financial", "income", "salary", "pay", "trading", "stock", "loan", "loan application"],
             Category.CAREER: ["job", "career", "work", "employment", "business", "promotion", "interview"],
+            Category.PARTNER_HEALING: ["heal", "healing", "therapy", "therapist", "mature", "maturity", "growth", "grow"],
             Category.HEALTH: ["sick", "illness", "disease", "health", "recover", "die", "cure", "healing", "medical"],
             Category.LAWSUIT: ["court", "lawsuit", "legal", "judge", "trial", "litigation", "case"],
             Category.RELATIONSHIP: ["love", "relationship", "friend", "enemy", "romance", "dating", "go out", "go out with", "date", "ask out", "see each other", "like me", "interested in", "attracted to", "reconciliation", "reconcile", "get back together", "ex", "former", "past relationship", "breakup", "break up", "makeup", "make up", "together", "couple", "partner", "boyfriend", "girlfriend", "romantic", "crush", "feelings", "attraction"],
@@ -408,7 +409,13 @@ class TraditionalHoraryQuestionAnalyzer:
         possession_words = ["car", "house", "vehicle", "property", "possessions", "belongings", "assets", "furniture", "jewelry", "valuables"]
         if any(word in question for word in possession_words):
             return Category.MONEY, [word for word in possession_words if word in question]
-        
+
+        # PRIORITY 3: Partner healing or maturity questions
+        partner_words = ["partner", "spouse", "husband", "wife", "boyfriend", "girlfriend", "relationship"]
+        healing_words = ["heal", "healing", "therapy", "therapist", "mature", "maturity", "growth", "grow"]
+        if any(p in question for p in partner_words) and any(h in question for h in healing_words):
+            return Category.PARTNER_HEALING, [word for word in healing_words if word in question]
+
         # ENHANCED: Priority-based matching to handle overlapping keywords
         # Some words like "paralegal" contain "legal" but should match "education" not "lawsuit"
         
@@ -485,6 +492,9 @@ class TraditionalHoraryQuestionAnalyzer:
         elif question_type == Category.RELATIONSHIP:
             # ENHANCED: Relationship questions use L1/L7 axis (self vs others)
             houses.append(7)  # L1 = self, L7 = other person/partner
+
+        elif question_type == Category.PARTNER_HEALING:
+            houses = [7, 12]
 
         elif question_type == Category.PREGNANCY:
             if third_person_analysis and third_person_analysis.get("is_third_person"):
@@ -653,24 +663,33 @@ class TraditionalHoraryQuestionAnalyzer:
                     "third_person_pregnancy": True
                 }
             else:
-                # FIXED: For general questions, use 7th house. For derived house questions, use the actual target.
-                if question_type == Category.GENERAL:
-                    target_house = 7  # Traditional "other person" for general questions
-                elif question_type == Category.EDUCATION:
-                    target_house = 10  # L10 = success/honors for exams
-                elif question_type in [Category.RELATIONSHIP, Category.MARRIAGE] and 7 in houses:
-                    target_house = 7  # Relationship questions should use 7th house, not 8th
+                if question_type == Category.PARTNER_HEALING:
+                    significators = {
+                        "querent_house": 7,
+                        "quesited_house": 12,
+                        "moon_role": "co-significator of querent and general flow",
+                        "special_significators": {},
+                        "transaction_type": False,
+                    }
                 else:
-                    # For derived house questions (e.g., [1, 7, 8] for husband's possessions)
-                    target_house = houses[-1] if len(houses) > 1 else 7
-                
-                significators = {
-                    "querent_house": 1,  # Always 1st house
-                    "quesited_house": target_house,  # Use the final derived house
-                    "moon_role": "co-significator of querent and general flow",
-                    "special_significators": {},
-                    "transaction_type": False
-                }
+                    # FIXED: For general questions, use 7th house. For derived house questions, use the actual target.
+                    if question_type == Category.GENERAL:
+                        target_house = 7  # Traditional "other person" for general questions
+                    elif question_type == Category.EDUCATION:
+                        target_house = 10  # L10 = success/honors for exams
+                    elif question_type in [Category.RELATIONSHIP, Category.MARRIAGE] and 7 in houses:
+                        target_house = 7  # Relationship questions should use 7th house, not 8th
+                    else:
+                        # For derived house questions (e.g., [1, 7, 8] for husband's possessions)
+                        target_house = houses[-1] if len(houses) > 1 else 7
+
+                    significators = {
+                        "querent_house": 1,  # Always 1st house
+                        "quesited_house": target_house,  # Use the final derived house
+                        "moon_role": "co-significator of querent and general flow",
+                        "special_significators": {},
+                        "transaction_type": False
+                    }
         
         # Add natural significators based on question type
         if question_type == Category.MARRIAGE:
@@ -689,6 +708,9 @@ class TraditionalHoraryQuestionAnalyzer:
         elif question_type == Category.CAREER:
             significators["special_significators"]["sun"] = "honor and reputation"
             significators["special_significators"]["jupiter"] = "success"
+        elif question_type == Category.PARTNER_HEALING:
+            significators["special_significators"]["mars"] = "fever and inflammation"
+            significators["special_significators"]["saturn"] = "chronic illness"
         elif question_type == Category.HEALTH:
             significators["special_significators"]["mars"] = "fever and inflammation"
             significators["special_significators"]["saturn"] = "chronic illness"

--- a/backend/taxonomy.py
+++ b/backend/taxonomy.py
@@ -35,6 +35,7 @@ class Category(str, Enum):
     PROPERTY = "property"
     DEATH = "death"
     SPIRITUAL = "spiritual"
+    PARTNER_HEALING = "partner_healing"
 
     # Possession sub‑categories
     VEHICLE = "vehicle"
@@ -119,6 +120,7 @@ CATEGORY_DEFAULTS: Dict[Category, Dict[str, Any]] = {
     Category.PROPERTY: {"houses": [1, 4], "significators": {}, "natural_significators": {}, "contract": {}},
     Category.DEATH: {"houses": [1, 8], "significators": {}, "natural_significators": {}, "contract": {}},
     Category.SPIRITUAL: {"houses": [1, 9], "significators": {}, "natural_significators": {}, "contract": {}},
+    Category.PARTNER_HEALING: {"houses": [7, 12], "significators": {}, "natural_significators": {}, "contract": {}},
 }
 
 

--- a/backend/tests/test_question_analyzer.py
+++ b/backend/tests/test_question_analyzer.py
@@ -57,3 +57,13 @@ def test_health_question_houses():
     assert resolved["querent_house"] == 1
     assert resolved["quesited_house"] == 6
 
+
+def test_partner_healing_question():
+    analyzer = TraditionalHoraryQuestionAnalyzer()
+    question = "Will my partner heal and grow through therapy?"
+    question_lower = question.lower()
+    q_type, _ = analyzer._determine_question_type(question_lower)
+    assert q_type is Category.PARTNER_HEALING
+    houses, _ = analyzer._determine_houses(question_lower, q_type, None)
+    assert houses == [7, 12]
+


### PR DESCRIPTION
## Summary
- extend taxonomy with PARTNER_HEALING category defaulting to houses 7 and 12
- detect partner healing questions via new keywords and dedicated logic
- cover partner healing detection with tests

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a74483c5b083249031d521f51e6810