### PR TITLE
Add Mercury and L7 interaction rules

### DIFF
--- a/backend/rules_lilly_general_v1.yaml
+++ b/backend/rules_lilly_general_v1.yaml
@@ -35,6 +35,14 @@ rules:
     tier: special_topics
     description: Medical exceptions
     weight: 1.5
+  - id: S3
+    tier: special_topics
+    description: Mutual reception between L7 and Mercury
+    weight: 1.5
+  - id: S4
+    tier: special_topics
+    description: L7 imminent sign change
+    weight: 1.2
   - id: M1
     tier: moon
     description: Moon trine Sun
@@ -99,6 +107,10 @@ rules:
     tier: perfection
     description: Collection of light (negative)
     weight: -2.0
+  - id: P4
+    tier: perfection
+    description: Moon applying to Mercury
+    weight: 1.5
   - id: LC1
     tier: testimonies
     description: L10 fortunate

--- a/backend/tests/test_new_rules.py
+++ b/backend/tests/test_new_rules.py
@@ -1,0 +1,28 @@
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+sys.path.append(str(ROOT))
+sys.path.append(str(ROOT / "backend"))
+
+from rule_engine import evaluate_rules, get_rule_weight
+
+
+def test_perfection_rule_moon_applying_mercury():
+    assert evaluate_rules(["P4"]) == ["P4"]
+    assert get_rule_weight("P4") == 1.5
+
+
+def test_special_topic_mutual_reception_l7_mercury():
+    assert evaluate_rules(["S3"]) == ["S3"]
+    assert get_rule_weight("S3") == 1.5
+
+
+def test_special_topic_l7_sign_change():
+    assert evaluate_rules(["S4"]) == ["S4"]
+    assert get_rule_weight("S4") == 1.2
+
+
+def test_special_topic_priority():
+    # When both special topic rules fire, lowest ID wins
+    assert evaluate_rules(["S3", "S4"]) == ["S3"]


### PR DESCRIPTION
## Summary
- add special topic rules for mutual reception between L7 and Mercury and imminent sign change of L7
- add perfection rule for Moon applying to Mercury
- cover new rule IDs with regression tests

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a74b59fec08324a209a2228b5cec20